### PR TITLE
Fix "AFRAME is not defined"

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,6 @@
 // Browser distrubution of the A-Frame component.
 (function () {
-  if (!AFRAME) {
+  if (typeof AFRAME === 'undefined') {
     console.error('Component attempted to register before AFRAME was available.');
     return;
   }


### PR DESCRIPTION
You need to use `typeof` in this instance to avoid a ReferenceError.
