### PR TITLE
Require Aframe first, so that THREE.js is available to component.

### DIFF
--- a/examples/main.js
+++ b/examples/main.js
@@ -1,2 +1,3 @@
-var exampleComponent = require('../index.js').component;
-require('aframe-core').registerComponent('example', exampleComponent);
+var Aframe = require('aframe-core'),
+  component = require('../index.js').component;
+Aframe.registerComponent('client-controls', component);


### PR DESCRIPTION
I tried to define some static `THREE.Vector3` instances in index.js, during its initial load. Leaving aside for a moment that it was probably a bad idea, I was confused by the "THREE is not defined" error. Should I have added THREE.js as a `<script src="..."></script>` tag in my HTML file? Did I need THREE.js as an NPM dependency? If I do that, won't THREE.js be bundled with my `dist/*` files, and loaded twice for users already including Aframe?

The problem was that main.js loads my component before loading Aframe, and `window.THREE` is only defined after Aframe loads. I'd like to think there's a better way of doing this, but in case other users make the same mistake it might be safest to load Aframe first.
