### PR TITLE
Replace watchify with budo, remove 'build' command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .sw[ponm]
-examples/build.js
 examples/node_modules/
 gh-pages
 node_modules/

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="../build.js"></script>
+    <script src="../main.js"></script>
   </head>
   <body>
     <a-assets></a-assets>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Example component for A-Frame VR.",
   "main": "index.js",
   "scripts": {
-    "build": "browserify examples/main.js -o examples/build.js",
-    "dev": "watchify examples/main.js -o examples/build.js",
+    "dev": "budo examples/main.js --dir examples --port 8000 --live --open",
     "dist": "webpack browser.js dist/aframe-example-component.js && webpack -p browser.js dist/aframe-example-component.min.js",
     "postpublish": "npm run dist",
     "preghpages": "npm run build && rm -rf gh-pages && cp -r examples gh-pages",
@@ -37,6 +36,7 @@
     "aframe-core": "^0.1.0",
     "browserify": "^12.0.1",
     "browserify-css": "^0.8.3",
+    "budo": "^7.1.0",
     "chai": "^3.4.1",
     "chai-shallow-deep-equal": "^1.3.0",
     "ghpages": "0.0.3",
@@ -48,7 +48,6 @@
     "karma-mocha-reporter": "^1.1.3",
     "karma-sinon-chai": "^1.1.0",
     "mocha": "^2.3.4",
-    "watchify": "^3.6.1",
     "webpack": "^1.12.9"
   }
 }


### PR DESCRIPTION
A suggestion for #4. 

Thoughts:
- Having a server lets me test examples from a phone / cardboard, which I can't do on the filesystem.
- Live-reload is convenient.
- I don't think it's necessary to have a separate build step, or to generate "build.js" files at all - budo can serve the compiled JS in place of "main.js" without needing a new file.

watchify-server could similarly be used, but doesn't include live reload.
